### PR TITLE
Automate stable branch update, guard PRs

### DIFF
--- a/.github/workflows/advance-stable.yml
+++ b/.github/workflows/advance-stable.yml
@@ -1,0 +1,29 @@
+name: Advance stable branch
+
+on:
+  schedule:
+    # weekday mornings
+    - cron: '17 5 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  advance:
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup-acton
+        uses: actonlang/setup-acton@v1
+        with:
+          channel: 'stable'
+      - name: "Check out main"
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - run: make build
+      - run: make test
+      - name: "Fast-forward stable to main"
+        run: |
+          git push origin HEAD:refs/heads/stable

--- a/.github/workflows/retarget-stable-prs.yml
+++ b/.github/workflows/retarget-stable-prs.yml
@@ -1,0 +1,37 @@
+name: Retarget stable pull requests
+
+# `stable` is the default branch, so GitHub uses it as the base of each new pull
+# request. But `stable` is only supposed to move with fast-forward merges from `main`.
+#
+# `pull_request_target` gives this workflow a writable token on pull requests
+# from forks. It also runs a copy of this workflow on the base branch, so a PR
+# can't disable it.
+
+on:
+  pull_request_target:
+    # `synchronize` ensures the check runs and fails again if new commits are pushed
+    types: [opened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  retarget:
+    name: "PR base branch"
+    if: github.event.pull_request.base.ref == 'stable'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: "Retarget to main"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --base main; then
+            gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body \
+              "Moved the base branch of this pull request to \`main\`. The \`stable\` branch only moves by fast-forward from \`main\`, so it cannot take pull requests; GitHub proposed it because it is the repository default branch. See [docs/development.md](https://github.com/$GITHUB_REPOSITORY/blob/main/docs/development.md)."
+            exit 0
+          fi
+
+          echo "::error title=Retarget this pull request to main::Could not move this pull request off 'stable' automatically. The 'stable' branch only moves by fast-forward from 'main', so it cannot take pull requests. Edit this pull request and change the base branch to 'main'."
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ACTON_CHANNEL: ${{ (github.ref == 'refs/heads/stable' || github.base_ref == 'stable') && 'stable' || 'tip' }}
+
 jobs:
   build-and-test:
     # Local push + fork PRs only (local PRs are skipped because push ran them).
@@ -16,13 +19,14 @@ jobs:
       - id: setup-acton
         uses: actonlang/setup-acton@v1
         with:
-          channel: 'tip'
+          channel: ${{ env.ACTON_CHANNEL }}
       - name: "Check out repository code"
         uses: actions/checkout@v4
       - name: "Check dependency consistency"
         run: make check-dep-consistency
       - name: "Cache acton stuff"
         uses: actions/cache@v4
+        if: env.ACTON_CHANNEL == 'tip'
         with:
           path: |
             ~/.cache/acton


### PR DESCRIPTION
The default `stable` branch is built with Acton stable and is automatically kept in sync with `main` if possible.