### PR TITLE
Share platform dependencies with the spec

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -25,9 +25,7 @@ dependencies = {
         hash="N-V-__8AAAUlAACtZkFcqozk8OGOfg8WsuqymxfDJtVwIjEA"
     ),
     "yang": (
-        repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        follows="stratoweave.yang"
     )
 }
 zig_dependencies = {}

--- a/Build.act
+++ b/Build.act
@@ -2,9 +2,7 @@ name = "sorespo"
 fingerprint = 0x9221cfef6ab1263c
 dependencies = {
     "lmdb": (
-        repo_url="https://github.com/stratoweave/acton-lmdb",
-        url="https://github.com/stratoweave/acton-lmdb/archive/05c9a1ae51360443150e002a9f7effac5a0be884.zip",
-        hash="N-V-__8AAJ8BAQBaDaW6N50DeQxT7GngYhvgGmTTKZX93ttB"
+        follows="stratoweave.lmdb"
     ),
     "rtrsecrets": (
         repo_url="https://github.com/stratoweave/rtrsecrets.git",
@@ -15,9 +13,7 @@ dependencies = {
         path="spec"
     ),
     "stratoweave": (
-        repo_url="https://github.com/stratoweave/stratoweave",
-        url="https://github.com/stratoweave/stratoweave/archive/5a75b454c47d90a642943d8476c72fbd3d2bd851.zip",
-        hash="N-V-__8AAA8RZwDiFQBkoU0NXHbKGMljJSqVBiu4WewPhsMX"
+        follows="spec.stratoweave"
     ),
     "timeseries": (
         repo_url="https://github.com/stratoweave/timeseries",

--- a/Build.act
+++ b/Build.act
@@ -1,9 +1,6 @@
 name = "sorespo"
 fingerprint = 0x9221cfef6ab1263c
 dependencies = {
-    "lmdb": (
-        follows="stratoweave.lmdb"
-    ),
     "rtrsecrets": (
         repo_url="https://github.com/stratoweave/rtrsecrets.git",
         url="https://github.com/stratoweave/rtrsecrets/archive/a8bdd0c0c95f8cd4fca127b4542d4bceb66b01e7.zip",

--- a/spec/Build.act
+++ b/spec/Build.act
@@ -12,9 +12,7 @@ dependencies = {
         hash="N-V-__8AAB8CBQDmnpKQJ8BSXB3kkcnFwNDiOecMocjMpVv8"
     ),
     "yang": (
-        repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        follows="stratoweave.yang"
     )
 }
 zig_dependencies = {}

--- a/spec/Build.act
+++ b/spec/Build.act
@@ -7,9 +7,7 @@ dependencies = {
         hash="N-V-__8AAA8RZwDiFQBkoU0NXHbKGMljJSqVBiu4WewPhsMX"
     ),
     "tmf": (
-        repo_url="https://github.com/stratoweave/actmf",
-        url="https://github.com/stratoweave/actmf/archive/5438703680537525671e4d203af01bd7a3cb4f3e.zip",
-        hash="N-V-__8AAB8CBQDmnpKQJ8BSXB3kkcnFwNDiOecMocjMpVv8"
+        follows="stratoweave.actmf"
     ),
     "yang": (
         follows="stratoweave.yang"


### PR DESCRIPTION
The application and spec currently pin shared dependencies separately. Keep the StratoWeave pin in spec and have the application follow it, so generation and runtime share the same selection. Follow StratoWeave's YANG and TMF dependencies and remove the unused direct LMDB declaration.

Uses the dependency follows support added in actonlang/acton#3091.
